### PR TITLE
Fix RGB escape bug

### DIFF
--- a/ansiwrap/ansistate.py
+++ b/ansiwrap/ansistate.py
@@ -86,7 +86,7 @@ class ANSIState(object):
             if isinstance(c, str):
                 return [c]
             if isinstance(c, (tuple, list, set)):
-                return ';'.join(str(p) for p in c)
+                return [';'.join(str(p) for p in c)]
             return [str(c)]
 
         raw_parts = []


### PR DESCRIPTION
I've noticed that the last commit to this file did not fix the bug for RGB escapes - this PR does that, so that strings with RGB colours escapes can be wrapped properly.

I'd appreciate if you could do a pip release with this, as I would like to have code depend on it.