### PR TITLE
Issue with ANSI codes in indent string

### DIFF
--- a/test/test_ansiwrap.py
+++ b/test/test_ansiwrap.py
@@ -266,3 +266,8 @@ def test_shorten_trivial():
     assert shorten(' ', 50) == ''
     assert shorten('   ', 55) == ''
 
+def test_wrap_ansi_in_indent():
+    s = red('this is a very long line')
+    indent = yellow('>')
+    assert wrap(s, 20, indent=indent) == ['\x1b[33m>\x1b[0m\x1b[31mthis is a very long\x1b[0m',
+                                          '\x1b[33m>\x1b[0m\x1b[31mline\x1b[0m']

--- a/test/test_ansiwrap.py
+++ b/test/test_ansiwrap.py
@@ -271,3 +271,14 @@ def test_wrap_ansi_in_indent():
     indent = yellow('>')
     assert wrap(s, 20, indent=indent) == ['\x1b[33m>\x1b[0m\x1b[31mthis is a very long\x1b[0m',
                                           '\x1b[33m>\x1b[0m\x1b[31mline\x1b[0m']
+
+def test_wrap_ansi_in_indent_different_indents():
+    s = red('this is a very long line')
+    initial_indent = yellow('>')
+    subsequent_indent = yellow('>>>')
+    assert wrap(s, 10, initial_indent=initial_indent, subsequent_indent=subsequent_indent) == [
+        '\x1b[33m>\x1b[0m\x1b[31mthis is a\x1b[0m',
+        '\x1b[33m>>>\x1b[0m\x1b[31mvery\x1b[0m',
+        '\x1b[33m>>>\x1b[0m\x1b[31mlong\x1b[0m',
+        '\x1b[33m>>>\x1b[0m\x1b[31mline\x1b[0m'
+    ]


### PR DESCRIPTION
If using ANSI codes in the indent string itself, the wrapped output is incorrect, since the continuation ANSI codes are inserted at the beginning of the line. They should be inserted after the indent.

This PR only adds a unit test, not sure what's a clean way to handle this looking at the code...